### PR TITLE
refactor: Update GithubEdit, OpenGraph, and CollectionList components 

### DIFF
--- a/.vscode/astro.code-snippets
+++ b/.vscode/astro.code-snippets
@@ -19,8 +19,8 @@
 		"prefix": "blogpost",
 		"body": [
 			"---",
-			"title: '${1:Blog Post Titled Here}'",
-			"pubDate: ${2:2022-07-01}",
+			"title: '${1:Blog Post Title Here}'",
+			"pubDate: ${2:${CURRENT_YEAR}-${CURRENT_MONTH}-${CURRENT_DATE}",
 			"description: '${3:This is the first post of my new Astro blog.}'",
 			"author: '${4:Astro Basics}'",
 			"image:",

--- a/src/components/CollectionList.astro
+++ b/src/components/CollectionList.astro
@@ -1,0 +1,108 @@
+---
+import { getCollection } from "astro:content";
+import type { SortType } from "#utils/types";
+import BlogPosts from "./astro/BlogPosts.astro";
+import { PAGINATION_COUNT } from "#utils/site-config";
+import type { TODO } from "#utils/types";
+import Placeholder from "#components/views/Placeholder.astro";
+import Pagination from "#components/astro/Pagination.astro";
+import Img from "#components/astro/Img.astro";
+
+/**
+ * The props for the CollectionList component.
+ * @typedef {Object} Props
+ * @property {string} [contentTitle] - The title to display for the collection.
+ * @property {number} [pageSize] - The number of items per page.
+ * @property {string} [to] - The link for the "View All" button.
+ * @property {any} [collection] - The collection to display.
+ */
+export type Props = {
+  collectionTitle?: string;
+  pageSize?: number;
+  to?: string;
+  collection?: TODO;
+  startCount?: number;
+  category?: string[];
+  itemsPerPage?: number;
+  showPagination?: boolean;
+};
+
+const {
+  collectionTitle,
+  pageSize,
+  to,
+  collection,
+  startCount,
+  itemsPerPage,
+  showPagination,
+} = Astro.props;
+const category = Astro.props.category || ["guides", "patterns", "resources"];
+const collectionResults = (await getCollection(collection || "posts"))
+  .filter(({ data: data }) => {
+    return category
+      ? data.draft === false && category.includes(data.category)
+      : data.draft === false;
+  })
+  .sort(
+    (a: SortType, b: SortType) =>
+      b.data.pubDate.getTime() - a.data.pubDate.getTime()
+  )
+  .slice(startCount || 0, pageSize || PAGINATION_COUNT || 3);
+---
+
+<>
+  {
+    collectionResults.length === 0 ? (
+      <>
+        <Placeholder />
+      </>
+    ) : (
+      <>
+        <>
+          {collectionTitle && <h3 data-ui="display">{collectionTitle}</h3>}
+          {collectionResults?.map((post: TODO) => (
+            <>
+              <article>
+                <BlogPosts
+                  title={post.data.title}
+                  description={post.data?.summary || post.data.description}
+                  url={`/${to || "posts"}/${post.slug}`}
+                  descId={`desc-${post.slug}`}
+                >
+                  <p>
+                    {post.data.image && post.data?.image && (
+                      <Img
+                        imgSrc={post.data.image.url}
+                        imgAlt={post.data.image?.alt}
+                        imgCaption={post.data.image?.caption}
+                      />
+                    )}
+                  </p>
+                </BlogPosts>
+                <div class="align-right">
+                  <a
+                    href={`/${to || "posts"}/${post.slug}`}
+                    aria-label={`Continue reading ${post.data.title}`}
+                  >
+                    <i aria-hidden="true">Continue reading</i>
+                  </a>
+                </div>
+              </article>
+            </>
+          ))}
+        </>
+        {showPagination && (
+          <>
+            <p>
+              <hr />
+              <Pagination
+                collection={collection}
+                itemsPerPage={pageSize || itemsPerPage || PAGINATION_COUNT}
+              />
+            </p>
+          </>
+        )}
+      </>
+    )
+  }
+</>

--- a/src/components/Feature.astro
+++ b/src/components/Feature.astro
@@ -1,0 +1,28 @@
+---
+import FeatureView from "./FeatureView.astro";
+import Patterns from "./views/Patterns.astro";
+import Guides from "./views/Guides.astro";
+import Reviews from "./views/Reviews.astro";
+---
+
+<FeatureView
+  showButton={true}
+  link="/patterns"
+  buttonAriaLabel="Contimue reading, inclusive patterns"
+>
+  <Patterns />
+</FeatureView>
+<FeatureView
+  showButton={true}
+  link="/guides"
+  buttonAriaLabel="Continue reading, A11y guides"
+>
+  <Guides />
+</FeatureView>
+<FeatureView
+  showButton={true}
+  link="/resources"
+  buttonAriaLabel="Continue reading, reviews and resources"
+>
+  <Reviews />
+</FeatureView>

--- a/src/components/FeatureView.astro
+++ b/src/components/FeatureView.astro
@@ -1,0 +1,28 @@
+---
+export type Props = {
+  link?: string;
+  showButton?: boolean;
+  className?: string;
+  buttonAriaLabel?: string;
+  style?: {};
+};
+
+const { link, showButton, className, buttonAriaLabel, style } = Astro.props;
+---
+
+<div class={`features`} style={style} data-grid>
+  <slot />
+  {
+    showButton && (
+      <div class="align-right">
+        <a
+          href={link || "#"}
+          class="button-continue"
+          aria-label={buttonAriaLabel || "Continue reading"}
+        >
+          <b aria-hidden="true">Continue reading </b>
+        </a>
+      </div>
+    )
+  }
+</div>

--- a/src/components/GithubEdit.astro
+++ b/src/components/GithubEdit.astro
@@ -1,0 +1,20 @@
+---
+import type { HTMLAttributes } from "astro/types";
+export interface Props extends HTMLAttributes<"a"> {
+  slug?: string;
+  user?: string;
+  repo?: string;
+  branch?: string;
+  path?: string;
+}
+
+const { slug, branch, path, repo, user, ...attrs } = Astro.props;
+
+const editPath = `https://github.com/${user || "shawn-sandy"}/${repo || "a11y-cafe"}/edit/${branch || "main"}${path || "/src/content/posts/"}${slug}.mdx`;
+---
+
+<>
+  <a href={editPath} target="_blank" rel="noopener noreferrer" {...attrs}>
+    <i> Edit on Github</i>
+  </a>
+</>

--- a/src/components/GithubEdit.md
+++ b/src/components/GithubEdit.md
@@ -1,0 +1,40 @@
+
+# GithubEdit Component
+
+The `GithubEdit` component is an Astro component that generates a link to edit the current file on GitHub. It takes in the following props:
+
+```js
+export type Props = {
+  slug?: string; // The slug of the file to edit
+  user?: string; // The GitHub username
+  repo?: string; // The GitHub repository name
+  branch?: string; // The branch to edit
+  path?: string; // The path to the file
+};
+```
+
+## Usage
+
+---
+
+```astro
+## import GithubEdit from '../components/GithubEdit.astro';
+
+<GithubEdit slug="my-post" user="myusername" repo="my-repo" branch="main" path="/src/content/posts/" />
+```
+
+This will render a link to edit the file `my-post.mdx` in the `my-repo`
+repository, owned by `myusername`, on the `main` branch, located at
+`/src/content/posts/`.
+
+If any of the props are not provided, the component will use the following
+defaults:
+
+- `user`: "shawn-sandy"
+- `repo`: "a11y-cafe"
+- `branch`: "main"
+- `path`: "/src/content/posts/"
+
+So if you don't provide any props, it will render a link to edit the current
+file in the `shawn-sandy/a11y-cafe` repository, on the `main` branch, located at
+`/src/content/posts/`.

--- a/src/components/GithubSupport.astro
+++ b/src/components/GithubSupport.astro
@@ -1,0 +1,29 @@
+---
+import type { HTMLAttributes } from "astro/types";
+export interface Props extends HTMLAttributes<"a"> {
+  issueTitle: string;
+  issueDescription?: string;
+  issueLabel?: string;
+  issueRepository?: string;
+  issueTemplate?: string;
+  repoProvider?: string;
+}
+
+const {
+  issueTitle,
+  issueDescription,
+  issueLabel,
+  issueRepository,
+  repoProvider,
+  issueTemplate,
+  ...attrs
+} = Astro.props;
+
+const gitHubUrl = `${repoProvider || "https://github.com"}/${issueRepository}/issues/new?template=${issueTemplate || "BUG_REPORT.md"}&title=${encodeURIComponent(issueTitle)}&body=${issueDescription ? encodeURIComponent(issueDescription) : ""}`;
+---
+
+<>
+  <a href={gitHubUrl} target="_blank" rel="noopener noreferrer" {...attrs}>
+    <i>{issueLabel || "Open an issue"}</i>
+  </a>
+</>

--- a/src/components/OpenGraph.astro
+++ b/src/components/OpenGraph.astro
@@ -1,0 +1,33 @@
+---
+export type Props = {
+  /** Description of the page */
+  description: string;
+  /** Title of the page */
+  title: string;
+  /** URL of the page */
+  url: string;
+  /** Optional image URL for the page */
+  image?: string;
+  imgWidth?: string;
+  imgHeight?: string;
+  /** Optional type of the page, either "website" or "article" */
+  type?: "website" | "article" | "book" | "profile";
+  /** Twitter username */
+  twitterUsername?: string;
+};
+const { description, title, url, image, type, twitterUsername, imgHeight, imgWidth } = Astro.props;
+---
+
+<meta property="og:title" content={title} />
+<meta property="og:type" content={type || "website"} />
+<meta property="og:image" content={image} />
+<meta property="og:url" content={url} />
+<meta property="og:description" content={description} />
+<!-- Twitter -->
+<meta property="og:image:width" content={imgWidth || "1280"} />
+<meta property="og:image:height" content={imgHeight || "640"} />
+<meta property="twitter:card" content="summary_large_image" />
+<meta property="twitter:image" content={image} />
+<meta property="twitter:site" content={twitterUsername} />
+
+ 


### PR DESCRIPTION
- Update GithubEdit component to dynamically generate edit link with user,
  repo, branch, path, and slug props.
- Update OpenGraph component to allow for optional image, image width, image
  height, type, and Twitter username props.
- Update CollectionList component to filter and sort collection based on
  category and show pagination option.